### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gatus.yml
+++ b/.github/workflows/gatus.yml
@@ -1,4 +1,6 @@
 name: Update Gatus Configuration
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:  


### PR DESCRIPTION
Potential fix for [https://github.com/ismailperim/homelab/security/code-scanning/3](https://github.com/ismailperim/homelab/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to explicitly define the least privileges required. Since the workflow involves checking out the repository and running an Ansible playbook, it only needs `contents: read` permissions. This ensures the workflow can read the repository contents without granting unnecessary write permissions.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
